### PR TITLE
Use a loop to process files

### DIFF
--- a/RCT2 Sound Conversion.bat
+++ b/RCT2 Sound Conversion.bat
@@ -1,56 +1,10 @@
-::Css1 is a special sound effects file that is not yet supported
-::flac.exe -8 -f css1.dat
-::
-::Css10 and Css16 are nearly empty and are probably unused.
-::flac.exe -8 -f css10.dat
-::flac.exe -8 -f css16.dat
-::
 ::Convert WAVs (saved as "DAT") using FLAC compression level 8 (maximum compression)
 @echo off
 echo Messages about "skipping unknown chunk 'fact'" are normal.
-flac.exe -8 -f css11.dat
-flac.exe -8 -f css12.dat
-flac.exe -8 -f css13.dat
-flac.exe -8 -f css14.dat
-flac.exe -8 -f css15.dat
-flac.exe -8 -f css17.dat
-flac.exe -8 -f css18.dat
-flac.exe -8 -f css19.dat
-flac.exe -8 -f css2.dat
-flac.exe -8 -f css20.dat
-flac.exe -8 -f css21.dat
-flac.exe -8 -f css22.dat
-flac.exe -8 -f css23.dat
-flac.exe -8 -f css24.dat
-flac.exe -8 -f css25.dat
-flac.exe -8 -f css26.dat
-flac.exe -8 -f css27.dat
-flac.exe -8 -f css28.dat
-flac.exe -8 -f css29.dat
-flac.exe -8 -f css3.dat
-flac.exe -8 -f css30.dat
-flac.exe -8 -f css31.dat
-flac.exe -8 -f css32.dat
-flac.exe -8 -f css33.dat
-flac.exe -8 -f css34.dat
-flac.exe -8 -f css35.dat
-flac.exe -8 -f css36.dat
-flac.exe -8 -f css37.dat
-flac.exe -8 -f css38.dat
-flac.exe -8 -f css39.dat
-flac.exe -8 -f css4.dat
-flac.exe -8 -f css40.dat
-flac.exe -8 -f css41.dat
-flac.exe -8 -f css42.dat
-flac.exe -8 -f css43.dat
-flac.exe -8 -f css44.dat
-flac.exe -8 -f css45.dat
-flac.exe -8 -f css46.dat
-flac.exe -8 -f css5.dat
-flac.exe -8 -f css6.dat
-flac.exe -8 -f css7.dat
-flac.exe -8 -f css8.dat
-flac.exe -8 -f css9.dat
+for /F "tokens=1 eol=:" %%a in (files.txt) do (
+  flac.exe -8 -f %%a
+)
+
 echo FLAC conversion (part 1 of 2) is done. You may want to scroll and verify that it worked. Messages about "skipping unknown chunk 'fact'" are normal.
 ::Wait for user input
 pause

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,46 @@
+:css1.dat special sound effects file that is not yet supported
+css2.dat
+css3.dat
+css4.dat
+css5.dat
+css6.dat
+css7.dat
+css8.dat
+css9.dat
+:css10.dat nearly empty, probably unused
+css11.dat
+css12.dat
+css13.dat
+css14.dat
+css15.dat
+:css16.dat nearly empty, probably unused
+css17.dat
+css18.dat
+css19.dat
+css20.dat
+css21.dat
+css22.dat
+css23.dat
+css24.dat
+css25.dat
+css26.dat
+css27.dat
+css28.dat
+css29.dat
+css30.dat
+css31.dat
+css32.dat
+css33.dat
+css34.dat
+css35.dat
+css36.dat
+css37.dat
+css38.dat
+css39.dat
+css40.dat
+css41.dat
+css42.dat
+css43.dat
+css44.dat
+css45.dat
+css46.dat


### PR DESCRIPTION
Taking out the filenames and using a loop to process them allows for easier future modifications and ports.